### PR TITLE
fix def-transfer with no options map null pointer

### DIFF
--- a/src/byte_streams.clj
+++ b/src/byte_streams.clj
@@ -77,7 +77,7 @@
       (eval
         `(fn [~(with-meta (first params) {:tag src})
               ~(with-meta (second params) {:tag dst})
-              ~(if-let [options (nth params 2)] options (gensym "options"))]
+              ~(if-let [options (get params 2)] options (gensym "options"))]
            ~@body)))))
 
 (defn seq-of [x]


### PR DESCRIPTION
When defining a def-transfer with no options map, the call to `nth` will throw a null pointer exception.  Change to `get` in order to return `nil` to if statement instead.
