### PR TITLE
Fixed incorrect use of condp

### DIFF
--- a/src/byte_streams.clj
+++ b/src/byte_streams.clj
@@ -935,13 +935,14 @@
           (instance? String b)))
     (cmp-bufs (to-byte-buffer a) (to-byte-buffer b))
     (loop [a (to-byte-buffers a), b (to-byte-buffers b)]
-      (condp empty?
-        a
+      (cond
+        (empty? a)
         (if (empty? b) 0 -1)
 
-        b
+        (empty? b)
         1
 
+        :else
         (let [cmp (cmp-bufs (first a) (first b))]
           (if (p/== 0 cmp)
             (recur (rest a) (rest b))


### PR DESCRIPTION
This results in the following error:
ArityException Wrong number of args (2) passed to: core$empty-QMARK-
    byte-streams/compare-bytes (byte_streams.clj:933)
