### PR TITLE
`def-transfer`: emit correct `:tag` metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,8 @@ jobs:
       # run tests!
       - run: lein with-profile ci do clean, test
 
+      - run: lein eastwood
+
   deploy:
     docker:
       # specify the version you desire here

--- a/project.clj
+++ b/project.clj
@@ -21,6 +21,7 @@
   :test-selectors {:stress :stress
                    :default (complement :stress)}
   :plugins [[lein-codox "0.10.3"]
+            [jonase/eastwood "0.4.3"]
             [lein-jammin "0.1.1"]
             [ztellman/lein-cljfmt "0.1.10"]]
   :cljfmt {:indents {#".*" [[:inner 0]]}}

--- a/src/byte_streams.clj
+++ b/src/byte_streams.clj
@@ -102,24 +102,22 @@
     :else
     (g/type (eval x))))
 
-(defn- extract-class [^Type src]
-  (when (and (instance? Class (.type src))
-             (not (.wrapper src)))
-    (if (= src (normalize-type-descriptor 'bytes))
-      'bytes
-      (.getName ^Class (.type src)))))
+(defn- tag-metadata-for [^Type src]
+  (if (and (instance? Class (.type src))
+           (not (.wrapper src)))
+    {:tag (if (= src (normalize-type-descriptor 'bytes))
+            'bytes
+            (.getName ^Class (.type src)))}
+    {}))
 
 (defmacro def-conversion
   "Defines a conversion from one type to another."
   [[src dst :as conversion] params & body]
   (let [^Type src (normalize-type-descriptor src)
-        dst (normalize-type-descriptor dst)
-        src-meta (if-let [c (extract-class src)]
-                   {:tag c}
-                   {})]
+        dst (normalize-type-descriptor dst)]
     `(let [f#
            (fn [~(with-meta (first params)
-                   src-meta)
+                   (tag-metadata-for src))
                 ~(if-let [options (second params)]
                    options
                    `_#)]
@@ -135,12 +133,8 @@
   [[src dst] params & body]
   (let [src (normalize-type-descriptor src)
         dst (normalize-type-descriptor dst)
-        src-meta (if-let [c (extract-class src)]
-                   {:tag c}
-                   {})
-        dst-meta (if-let [c (extract-class dst)]
-                   {:tag c}
-                   {})]
+        src-meta (tag-metadata-for src)
+        dst-meta (tag-metadata-for dst)]
     `(swap! src->dst->transfer assoc-in [~src ~dst]
        (fn [~(with-meta (first params) src-meta)
             ~(with-meta (second params) dst-meta)

--- a/src/byte_streams/utils.clj
+++ b/src/byte_streams/utils.clj
@@ -26,7 +26,7 @@
   [[x it] & body]
   (let [it-sym (gensym "iterable")]
     `(let [~it-sym ~it
-           it# (.iterator ~(with-meta it-sym {:tag "Iterable"}))]
+           it# (.iterator ~(with-meta it-sym {:tag 'java.lang.Iterable}))]
        (loop []
          (when (.hasNext it#)
            (let [~x (.next it#)]

--- a/test/byte_streams_test.clj
+++ b/test/byte_streams_test.clj
@@ -1,7 +1,6 @@
 (ns byte-streams-test
-  (:use
-    [byte-streams])
   (:require
+    [byte-streams :refer [bytes= compare-bytes conversion-path convert dev-null possible-conversions seq-of stream-of to-byte-array to-byte-buffer to-byte-buffers to-input-stream to-string transfer vector-of]]
     [clojure.test :refer :all]
     [byte-streams.char-sequence :as cs])
   (:refer-clojure


### PR DESCRIPTION
Reoccurrences are prevented by introducing Eastwood as a linter, which detected this issue in the first place.

Fixes https://github.com/clj-commons/byte-streams/issues/45