### PR TITLE
Remove use of clj-tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ byte-streams> (compare-bytes "abc" "abd")
 `byte-streams/conversion-path` returns all the intermediate steps in transforming one type to another, if one exists:
 
 ```clojure
-;; each element is a conversion tuple of to/from
+;; each element is a conversion pair of to/from
 byte-streams> (conversion-path java.io.File String)
 ([java.io.File java.nio.channels.ReadableByteChannel]
  [#'byte-streams/ByteSource java.lang.CharSequence]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,6 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
   :dependencies [[primitive-math "0.1.6"]
-                 [clj-tuple "0.2.2"]
                  [manifold "0.1.9"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]
                                   [org.clojure/test.check "1.1.0"]

--- a/src/byte_streams/graph.clj
+++ b/src/byte_streams/graph.clj
@@ -1,7 +1,6 @@
 (ns byte-streams.graph
-  (:refer-clojure :exclude [vector type])
+  (:refer-clojure :exclude [type])
   (:require
-    [clj-tuple :refer [vector]]
     [manifold.stream :as s]
     [byte-streams
      [utils :refer [defprotocol+ defrecord+ deftype+]]


### PR DESCRIPTION
`clj-tuple` has been archived for years. It's still slightly faster than
standard Clojure `vector`, but doesn't support `hash` correctly it
seems, plus due to its age, it uses Java settings that are causing
problems.