### PR TITLE
Bugfix/closeable seq finalize

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,8 @@
-{:lint-as {byte-streams.utils/defprotocol+ clojure.core/defprotocol
-           byte-streams.utils/deftype+ clojure.core/deftype
-           byte-streams.utils/defrecord+ clojure.core/defrecord
-           byte-streams.utils/definterface+ clojure.core/definterface}}
+{:lint-as {byte-streams.utils/defprotocol+  clojure.core/defprotocol
+           byte-streams.utils/deftype+      clojure.core/deftype
+           byte-streams.utils/defrecord+    clojure.core/defrecord
+           byte-streams.utils/definterface+ clojure.core/definterface
+           clj-commons.byte-streams.utils/defprotocol+  clojure.core/defprotocol
+           clj-commons.byte-streams.utils/deftype+      clojure.core/deftype
+           clj-commons.byte-streams.utils/defrecord+    clojure.core/defrecord
+           clj-commons.byte-streams.utils/definterface+ clojure.core/definterface}}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dump*
 DS_Store
 .nrepl*
 .clj-kondo/.cache
+.eastwood

--- a/src/clj_commons/byte_streams.clj
+++ b/src/clj_commons/byte_streams.clj
@@ -9,46 +9,39 @@
      [protocols :as proto]
      [pushback-stream :as ps]
      [char-sequence :as cs]]
-    [clojure.java.io :as io]
     [clj-commons.primitive-math :as p])
   (:import
-    [clj_commons.byte_streams
-     Utils
-     ByteBufferInputStream]
-    [clj_commons.byte_streams.graph
-     Type]
-    [java.nio
-     ByteBuffer
-     DirectByteBuffer]
-    [java.lang.reflect
-     Array]
-    [java.util.concurrent.atomic
-     AtomicBoolean]
-    [java.io
-     File
-     FileOutputStream
-     FileInputStream
-     ByteArrayInputStream
-     ByteArrayOutputStream
-     PipedOutputStream
-     PipedInputStream
-     DataInputStream
-     InputStream
-     OutputStream
-     IOException
-     RandomAccessFile
-     Reader
-     InputStreamReader
-     BufferedReader]
-    [java.nio.channels
-     ReadableByteChannel
-     WritableByteChannel
-     FileChannel
-     FileChannel$MapMode
-     Channels
-     Pipe]
-    [java.nio.channels.spi
-     AbstractSelectableChannel]
+    (clj_commons.byte_streams
+      Utils
+      ByteBufferInputStream)
+    (clj_commons.byte_streams.graph
+      Type)
+    (java.nio
+      ByteBuffer)
+    (java.lang.reflect
+      Array)
+    (java.io
+      File
+      ByteArrayInputStream
+      ByteArrayOutputStream
+      PipedOutputStream
+      PipedInputStream
+      DataInputStream
+      InputStream
+      OutputStream
+      IOException
+      Reader
+      BufferedReader
+      InputStreamReader)
+    (java.nio.channels
+      ReadableByteChannel
+      WritableByteChannel
+      FileChannel
+      FileChannel$MapMode
+      Channels
+      Pipe)
+    (java.nio.channels.spi
+      AbstractSelectableChannel)
     (java.nio.file StandardOpenOption)))
 
 ;;;
@@ -594,7 +587,9 @@
         (.toPath)
         (FileChannel/open option-array))))
 
-(def-conversion ^{:cost 0} [File (seq-of ByteBuffer)]
+;;
+(def-conversion ^{:cost 0
+                  :doc "Assumes the file size is static."} [File (seq-of ByteBuffer)]
   [file {:keys [chunk-size writable?] :or {chunk-size (int 2e9), writable? false}}]
   (let [option-array (into-array StandardOpenOption
                                  (cond-> [StandardOpenOption/READ]

--- a/src/clj_commons/byte_streams/graph.clj
+++ b/src/clj_commons/byte_streams/graph.clj
@@ -194,25 +194,21 @@
       (close-fn)
       nil)
     (reify
-
       clojure.lang.IPending
       (isRealized [_]
         (or
           (not (instance? clojure.lang.IPending s))
           (realized? s)))
 
-      Object
-      (finalize [_]
-        (close-fn))
-
       java.io.Closeable
       (close [_]
         (close-fn))
 
       clojure.lang.Sequential
-      clojure.lang.ISeq
       clojure.lang.Seqable
       (seq [this] this)
+
+      clojure.lang.ISeq
       (cons [_ a]
         (closeable-seq (cons a s) exhaustible? close-fn))
       (next [this]

--- a/test/clj_commons/byte_streams_test.clj
+++ b/test/clj_commons/byte_streams_test.clj
@@ -145,7 +145,7 @@
   "Write out a file of nothing but zeros"
   [size]
   (let [f (doto (File/createTempFile "byte-streams-test-" nil)
-                #_(.deleteOnExit))
+                (.deleteOnExit))
         buf-size 64
         zs (byte-array buf-size (byte 0))
         num-bufs (int (quot size buf-size))


### PR DESCRIPTION
Fixes #37 by removing the `finalize` method from the closeable-seq that closes input streams/channels prematurely. 

Since the existing behavior was already broken, and many other conversions already require you manage/close resources yourself _anyway_, I'm comfortable making that the requirement.

While doing this, I looked over the other conversions, to see if any of them leaked file descriptors. The `File -> (seq-of ByteBuffer)` conversion was also subject to this problem, and did not close its own resources. It's been updated to automatically close the file upon exhaustion **(Maybe this should be an option? We wouldn't want to stop tailing a growing log file just because we temporarily caught up to the end...)**

I also updated the `File -> WritableByteChannel` and `File -> ReadableByteChannel` conversions. It wasn't 100% clear from the javadocs whether the linked streams would close when their channels did, so to avoid that, I bypassed the `File*Streams`.

Finally, a bunch of tests were added to prevent regressions, including one of a large file.