### PR TITLE
Fixes transfers to File when `append?` is true

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,8 +14,7 @@
                                   [rhizome "0.2.9"]
                                   [codox-md "0.2.0" :exclusions [org.clojure/clojure]]
                                   [criterium "0.4.6"]]}
-             :ci {:javac-options ["-target" "1.8" "-source" "1.8"]
-                  :dependencies [[org.clojure/clojure "1.11.1"]
+             :ci {:dependencies [[org.clojure/clojure "1.11.1"]
                                  [org.clojure/test.check "1.1.1"]
                                  [rhizome "0.2.9"]]}}
   :test-selectors {:stress :stress
@@ -30,4 +29,5 @@
           :namespaces [byte-streams]}
   :global-vars {*warn-on-reflection* true}
   :java-source-paths ["src"]
+  :javac-options ["-target" "1.8" "-source" "1.8"]
   :jvm-opts ^:replace ["-server" "-Xmx4g"])

--- a/src/clj_commons/byte_streams.clj
+++ b/src/clj_commons/byte_streams.clj
@@ -188,7 +188,6 @@
                  (or source-type
                      (type-descriptor x)))
            wrapper (.wrapper src)]
-
        (cond
 
          (not (nil? (.type src)))
@@ -276,7 +275,6 @@
                             (remove nil?)
                             first)]
           (cond
-
             (and src' dst')
             (let [f (get-in @src->dst->transfer [src' dst'])]
               (fn [source sink options]
@@ -284,20 +282,19 @@
                       sink' (convert sink dst' options)]
                   (f source' sink' options))))
 
-            (and
-              (converter-fn src (g/type #'proto/ByteSource))
-              (converter dst (g/type #'proto/ByteSink)))
-            (fn [source sink {:keys [close?] :or {close? true} :as options}]
-              (let [source' (convert source #'proto/ByteSource options)
-                    sink' (convert sink #'proto/ByteSink options)]
-                (default-transfer source' sink' options)
-                (when close?
-                  (doseq [x [source sink source' sink']]
-                    (when (proto/closeable? x)
-                      (proto/close x))))))
+          (and (converter-fn src (g/type #'proto/ByteSource))
+               (converter dst (g/type #'proto/ByteSink)))
+          (fn [source sink {:keys [close?] :or {close? true} :as options}]
+            (let [source' (convert source #'proto/ByteSource options)
+                  sink' (convert sink #'proto/ByteSink options)]
+              (default-transfer source' sink' options)
+              (when close?
+                (doseq [x [source sink source' sink']]
+                  (when (proto/closeable? x)
+                    (proto/close x))))))
 
-            :else
-            nil))))))
+          :else
+          nil))))))
 
 ;; for byte transfers
 (defn transfer

--- a/src/clj_commons/byte_streams/graph.clj
+++ b/src/clj_commons/byte_streams/graph.clj
@@ -181,8 +181,9 @@
                     p
                     (do
                       (doseq [[[src dst] c] (->> curr
-                                              (possible-conversions g)
-                                              (remove (fn [[[src dst] c]] ((.visited? p) dst))))]
+                                                 (possible-conversions g)
+                                                 (remove (fn [[[src dst] c]]
+                                                           ((.visited? p) dst))))]
                         (.add q (conj-path p src dst c)))
                       (recur))))))))))))
 

--- a/test/byte_streams_reload_test.clj
+++ b/test/byte_streams_reload_test.clj
@@ -1,7 +1,0 @@
-(ns byte-streams-reload-test
-  (:require
-   [clojure.test :refer :all]))
-
-#_(deftest test-reload-all
-  (dotimes [_ 5]
-    (require 'byte-streams :reload-all)))

--- a/test/byte_streams_simple_check.clj
+++ b/test/byte_streams_simple_check.clj
@@ -1,4 +1,8 @@
-(ns byte-streams-simple-check
+(ns ^{:deprecated true
+      :doc "DEPRECATED: moved to clj-commons.byte-streams-simple-check"
+      :no-doc true
+      :superseded-by "clj-commons.byte-streams-simple-check"}
+  byte-streams-simple-check
   (:require
     [clojure.test :refer :all]
     [byte-streams :as bs]

--- a/test/byte_streams_test.clj
+++ b/test/byte_streams_test.clj
@@ -1,4 +1,8 @@
-(ns byte-streams-test
+(ns ^{:deprecated true
+      :doc "DEPRECATED: moved to clj-commons.byte-streams-test"
+      :no-doc true
+      :superseded-by "clj-commons.byte-streams-test"}
+  byte-streams-test
   (:require
     [byte-streams :refer [bytes= compare-bytes conversion-path convert dev-null possible-conversions seq-of stream-of to-byte-array to-byte-buffer to-byte-buffers to-input-stream to-string transfer vector-of]]
     [clojure.test :refer :all]

--- a/test/clj_commons/byte_streams_reload_test.clj
+++ b/test/clj_commons/byte_streams_reload_test.clj
@@ -1,7 +1,0 @@
-(ns clj-commons.byte-streams-reload-test
-  (:require
-   [clojure.test :refer :all]))
-
-#_(deftest test-reload-all
-  (dotimes [_ 5]
-    (require 'clj-commons.byte-streams :reload-all)))

--- a/test/pushback_stream_test.clj
+++ b/test/pushback_stream_test.clj
@@ -1,4 +1,8 @@
-(ns pushback-stream-test
+(ns ^{:deprecated true
+      :doc "DEPRECATED: moved to clj-commons.pushback-stream-test"
+      :no-doc true
+      :superseded-by "clj-commons.pushback-stream-test"}
+  pushback-stream-test
   (:require
     [clojure.test :refer :all]
     [byte-streams.pushback-stream :as p]))


### PR DESCRIPTION
Fixes #23...I think.

I have no idea why it would have worked on Linux, but not a Mac. I believe append-mode for File transfers should have been broken for all platforms, except when "appending" to empty files.

The current fix calls .position() on the FileChannel to know where to start. Normally a fresh FC will be at 0, except in append mode, when .position() will always return the current size of the file.

This doesn't handle multiple writers correctly, since it never calls .position() again, but there's a lot more work to do to make byte-streams compatible with that assumption, so we're not tackling that here.