### PR TITLE
Drop type-hints from `assoc-conversion` to work around AOT issue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,14 @@
                    :default (complement :stress)}
   :plugins [[jonase/eastwood "1.3.0"]
             [lein-cljfmt "0.9.0"]]
+  :eastwood {:ignored-faults {:reflection {clj-commons.byte-streams.graph [{:line 121}
+                                                                           {:line 122}
+                                                                           {:line 123}
+                                                                           {:line 124}]
+                                           byte-streams.graph [{:line 126}
+                                                               {:line 127}
+                                                               {:line 128}
+                                                               {:line 129}]}}}
   :global-vars {*warn-on-reflection* true}
   :java-source-paths ["src"]
   :javac-options ["-target" "1.8" "-source" "1.8"]

--- a/src/byte_streams/graph.clj
+++ b/src/byte_streams/graph.clj
@@ -118,11 +118,15 @@
   IConversionGraph
   (assoc-conversion [_ src dst f cost]
                     (let [m' (assoc-in m [src dst] (Conversion. f cost))
+                          ;; NOTE: These method calls are
+                          ;; intentionally done without type-hints to
+                          ;; work around
+                          ;; https://github.com/clj-commons/byte-streams/issues/68
                           m' (if (and
-                                  (nil? (.wrapper ^Type src))
-                                  (nil? (.wrapper ^Type dst)))
-                               (let [src (.type ^Type src)
-                                     dst (.type ^Type dst)]
+                                  (nil? (.wrapper src))
+                                  (nil? (.wrapper dst)))
+                               (let [src (.type src)
+                                     dst (.type dst)]
                                  (-> m'
                                      (assoc-in [(Type. 'seq src) (Type. 'seq dst)]
                                                (Conversion. (fn [x options] (map #(f % options) x)) cost))

--- a/src/clj_commons/byte_streams/graph.clj
+++ b/src/clj_commons/byte_streams/graph.clj
@@ -113,11 +113,15 @@
   IConversionGraph
   (assoc-conversion [_ src dst f cost]
                     (let [m' (assoc-in m [src dst] (Conversion. f cost))
+                          ;; NOTE: These method calls are
+                          ;; intentionally done without type-hints to
+                          ;; work around
+                          ;; https://github.com/clj-commons/byte-streams/issues/68
                           m' (if (and
-                                  (nil? (.wrapper ^Type src))
-                                  (nil? (.wrapper ^Type dst)))
-                               (let [src (.type ^Type src)
-                                     dst (.type ^Type dst)]
+                                  (nil? (.wrapper src))
+                                  (nil? (.wrapper dst)))
+                               (let [src (.type src)
+                                     dst (.type dst)]
                                  (-> m'
                                      (assoc-in [(Type. 'seq src) (Type. 'seq dst)]
                                                (Conversion. (fn [x options] (map #(f % options) x)) cost))


### PR DESCRIPTION
Since this function is usually not called at runtime, the reflection performance penalty should be tolerable.

Fixes #68